### PR TITLE
Fix new implementation of jenkins dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ RUN curl https://get.docker.com/builds/Linux/x86_64/docker-latest.tgz | tar xvz 
 
 COPY entrypoint.sh /usr/local/bin/
 
-ENTRYPOINT ["/bin/tini", "--", "/usr/local/bin/entrypoint.sh"]
+ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
" Error response from daemon: oci runtime error: container_linux.go:247: starting container process caused "exec: \"/bin/tini\": stat /bin/tini: no such file or directory"."