### PR TITLE
Add Configuration as Code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,11 @@ FROM jenkins/jenkins:alpine
 
 MAINTAINER trion development GmbH "info@trion.de"
 
-ENV JENKINS_USER=jenkins
+ENV JENKINS_USER=jenkins JAVA_OPTS=-Djenkins.install.runSetupWizard=false CASC_JENKINS_CONFIG=/var/jenkins_home/config.yaml
 USER root
+COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
+RUN /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/plugins.txt
+COPY config.yaml /var/jenkins_home/config.yaml
 COPY entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/entrypoint.sh"]
 RUN apk --no-cache add shadow su-exec

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ This docker image includes the docker command to enable Jenkins to interact with
 
 It includes a build of docker-compose working on alpine as well.
 
+The image does not start the initial Jenkins Setup Wizard. Instead the ```Configuration as Code``` plugin has been pre-installed and an initial location and admin credentials can be set using environment variables.
+Afterwards, the server can be managed as usual.
+
 ## Docker Socket integration
 
 If a bind-mount of the docker daemon socket is detected, appropriate permissions will be set to allow jenkins to access docker via the socket.
@@ -13,6 +16,7 @@ Example usage
 
 ```
 docker run -it --name=jenkins -e JENKINS_USER=$(id -u) --rm -p 8080:8080 -p 50000:50000 \
+--env JENKINS_ADMIN_ID=username --env JENKINS_ADMIN_PASSWORD=password --env JENKINS_LOCATION=http://localhost:8080 \
 -v $HOME/.jenkins:/var/ -v /var/run/docker.sock:/var/run/docker.sock \
 --name jenkins trion/jenkins-docker-client
 ```

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,22 @@
+jenkins:
+  securityRealm:
+    local:
+      allowsSignup: false
+      users:
+       - id: ${JENKINS_ADMIN_ID}
+         password: ${JENKINS_ADMIN_PASSWORD}
+  authorizationStrategy:
+    globalMatrix:
+      permissions:
+        - "Overall/Administer:${JENKINS_ADMIN_ID}"
+        - "Overall/Read:authenticated"
+  remotingSecurity:
+    enabled: true
+security:
+  queueItemAuthenticator:
+    authenticators:
+    - global:
+        strategy: triggeringUsersAuthorizationStrategy
+unclassified:
+  location:
+    url: ${JENKINS_LOCATION}

--- a/plugins.txt
+++ b/plugins.txt
@@ -1,0 +1,3 @@
+authorize-project:latest
+configuration-as-code:latest
+role-strategy:latest


### PR DESCRIPTION
Using the Jenkins Configuration as Code plugin to skip the setup wizard and set up basic authentication.

Based upon this tutorial:
https://www.digitalocean.com/community/tutorials/how-to-automate-jenkins-setup-with-docker-and-jenkins-configuration-as-code
